### PR TITLE
Add --non-interactive to the svn checkout

### DIFF
--- a/scripts.d/50-xvid.sh
+++ b/scripts.d/50-xvid.sh
@@ -9,7 +9,7 @@ ffbuild_enabled() {
 }
 
 ffbuild_dockerdl() {
-    echo "retry-tool sh -c \"rm -rf xvid && svn checkout --username 'anonymous' --password '' '${SCRIPT_REPO}@${SCRIPT_REV}' xvid\" && cd xvid"
+    echo "retry-tool sh -c \"rm -rf xvid && svn --non-interactive checkout --username 'anonymous' --password '' '${SCRIPT_REPO}@${SCRIPT_REV}' xvid\" && cd xvid"
 }
 
 ffbuild_dockerbuild() {


### PR DESCRIPTION
Otherwise svn checkout hang on an input from user about saving plaintext passwords