### PR TITLE
Fix Rust-Cross-Compilation once again

### DIFF
--- a/scripts.d/50-rav1e.sh
+++ b/scripts.d/50-rav1e.sh
@@ -10,7 +10,7 @@ ffbuild_enabled() {
 
 ffbuild_dockerbuild() {
     local myconf=(
-        --prefix="$FFBUILD_PREFIX"
+        --prefix="${FFBUILD_PREFIX}"
         --target="${FFBUILD_RUST_TARGET}"
         --library-type=staticlib
         --crt-static
@@ -23,6 +23,18 @@ ffbuild_dockerbuild() {
 
     # The pinned version is broken, and upstream does not react
     cargo update cc
+
+    export "AR_${FFBUILD_RUST_TARGET//-/_}"="${AR}"
+    export "RANLIB_${FFBUILD_RUST_TARGET//-/_}"="${RANLIB}"
+    export "NM_${FFBUILD_RUST_TARGET//-/_}"="${NM}"
+    export "LD_${FFBUILD_RUST_TARGET//-/_}"="${LD}"
+    export "CC_${FFBUILD_RUST_TARGET//-/_}"="${CC}"
+    export "CXX_${FFBUILD_RUST_TARGET//-/_}"="${CXX}"
+    export "LD_${FFBUILD_RUST_TARGET//-/_}"="${LD}"
+    export "CFLAGS_${FFBUILD_RUST_TARGET//-/_}"="${CFLAGS}"
+    export "CXXFLAGS_${FFBUILD_RUST_TARGET//-/_}"="${CXXFLAGS}"
+    export "LDFLAGS_${FFBUILD_RUST_TARGET//-/_}"="${LDFLAGS}"
+    unset AR RANLIB NM CC CXX LD CFLAGS CXXFLAGS LDFLAGS
 
     cargo cinstall -v "${myconf[@]}"
 


### PR DESCRIPTION
Not sure if semantics changed once again, or why this suddenly broke.